### PR TITLE
URL Cleanup

### DIFF
--- a/installing-flo.html.md.erb
+++ b/installing-flo.html.md.erb
@@ -16,10 +16,10 @@ This topic provides instructions for installing Flo for Spring XD.
 1. Clear your browser cache.
 
 1. Access Flo for Spring XD at the following URI endpoints:
-	* Main dashboard: `http://HOST_NAME:PORT/admin-ui`
-	* Stream creation: `http://HOST_NAME:PORT/admin-ui/#/streams/create`
-	* Health monitoring: `http://HOST_NAME:PORT/admin-ui/#/streams/definitions`
-	* Module throughput rates are visible at `http://HOST_NAME:PORT/admin-ui/#/streams/definitions`.
+	* Main dashboard: `https://HOST_NAME:PORT/admin-ui`
+	* Stream creation: `https://HOST_NAME:PORT/admin-ui/#/streams/create`
+	* Health monitoring: `https://HOST_NAME:PORT/admin-ui/#/streams/definitions`
+	* Module throughput rates are visible at `https://HOST_NAME:PORT/admin-ui/#/streams/definitions`.
 
 <p class='note'><strong>Note</strong>: If unchanged, the default PORT points to 9393.</p>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://HOST_NAME:PORT/admin-ui (UnknownHostException) with 1 occurrences migrated to:  
  https://HOST_NAME:PORT/admin-ui ([https](https://HOST_NAME:PORT/admin-ui) result UnknownHostException).
* http://HOST_NAME:PORT/admin-ui/ (UnknownHostException) with 3 occurrences migrated to:  
  https://HOST_NAME:PORT/admin-ui/ ([https](https://HOST_NAME:PORT/admin-ui/) result UnknownHostException).