### PR TITLE
URL Cleanup

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -40,7 +40,7 @@ Flo also offers a textual shell and graphical view for batch pipelines. As with 
 
 Unlike the palette for streaming pipelines, the palette for batch pipelines does not include out-of-the-box job modules. Job definitions for batch pipelines must first be created, and are then available in the palette, along with any already-defined composed jobs.
 
-Flo for Batch pipeline builds upon the newly supported Batch DSL in Spring XD, which  can be used to create composite batch workflows involving sequential jobs, parallel jobs or even the combination of the two. More details about the DSL is available in Spring XD’s reference documentation [link](http://docs.spring.io/spring-xd/docs/1.3.0.RC1/reference/html/#composed-jobs).
+Flo for Batch pipeline builds upon the newly supported Batch DSL in Spring XD, which  can be used to create composite batch workflows involving sequential jobs, parallel jobs or even the combination of the two. More details about the DSL is available in Spring XD’s reference documentation [link](https://docs.spring.io/spring-xd/docs/1.3.0.RC1/reference/html/#composed-jobs).
 
 The Flo canvas textual shell and drag-and-drop interface both support the Spring XD batch DSL. Job definitions in the DSL will be computed automatically for batch jobs composed in the drag-and-drop interface.
 

--- a/installing-flo.html.md.erb
+++ b/installing-flo.html.md.erb
@@ -23,4 +23,4 @@ This topic provides instructions for installing Flo for Spring XD.
 
 <p class='note'><strong>Note</strong>: If unchanged, the default PORT points to 9393.</p>
 
-<p class='note'><strong>Note</strong>: To see throughput rates for modules, you must enable JMX in your Spring XD cluster. By default it is disabled. Instructions for turning it on are <a href='http://docs.spring.io/spring-xd/docs/current/reference/html/#_monitoring_xd_admin_container_and_single_node_servers'>here</a>.</p>
+<p class='note'><strong>Note</strong>: To see throughput rates for modules, you must enable JMX in your Spring XD cluster. By default it is disabled. Instructions for turning it on are <a href='https://docs.spring.io/spring-xd/docs/current/reference/html/#_monitoring_xd_admin_container_and_single_node_servers'>here</a>.</p>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-xd/docs/1.3.0.RC1/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-xd/docs/1.3.0.RC1/reference/html/ ([https](https://docs.spring.io/spring-xd/docs/1.3.0.RC1/reference/html/) result 200).
* [ ] http://docs.spring.io/spring-xd/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-xd/docs/current/reference/html/ ([https](https://docs.spring.io/spring-xd/docs/current/reference/html/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://HOST_NAME:PORT/admin-ui with 1 occurrences
* http://HOST_NAME:PORT/admin-ui/ with 3 occurrences